### PR TITLE
Remove leading slashes from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,8 @@
-/.bundle
-/.convox
-/.env
-/.git
-/db/*.sqlite3
-/db/*.sqlite3-journal
-/log/*
-/tmp
+.bundle
+.convox
+.env
+.git
+db/*.sqlite3
+db/*.sqlite3-journal
+log/*
+tmp


### PR DESCRIPTION
The leading / is supported in .gitignore, but not in .dockerignore.
